### PR TITLE
Fix typo

### DIFF
--- a/internal/server/content_dev/index.html
+++ b/internal/server/content_dev/index.html
@@ -12,7 +12,7 @@ cd client
 yarn
 yarn build
 cd ..
-cp -r client/build/* internal/server/content
+cp -r client/build/* internal/server/content_dev
 </pre>
 </body>
 </html>  


### PR DESCRIPTION
Commit 715e6eb666c4ca18597404d2e7c6c81a32462d08 switch the web content from
internal/server/content to internal/server/content_dev but did not change the
build instructions. This fixes that.