### PR TITLE
Fix reopening closed event pipe

### DIFF
--- a/internal/client/named_pipe_unix.go
+++ b/internal/client/named_pipe_unix.go
@@ -112,6 +112,10 @@ func (pc *namedPipe) eventLoop() {
 	defer os.Remove(pc.eventPipeName)
 
 	for {
+		if pc.eventPipeName == "" {
+			return
+		}
+
 		output, err := openFifo(pc.eventPipeName, os.O_WRONLY)
 		if err != nil {
 			log.Error(err)
@@ -131,6 +135,8 @@ func (pc *namedPipe) close() {
 
 	os.Remove(pc.commandPipeName)
 	os.Remove(pc.eventPipeName)
+
+	pc.eventPipeName = ""
 }
 
 func createFifo(filename string) (err error) {


### PR DESCRIPTION
When a Close command is sent, the event loop tries to reopen the closed event
pipe. We remove the event pipe filename during the closing function and then
check for an empty filename during the event loop.